### PR TITLE
Fix copying osp network files

### DIFF
--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -27,7 +27,7 @@
         src:  "{{ item }}"
         dest: "{{ working_dir }}/osp-network/"
         mode: 0644
-      with_fileglob:
+      with_items:
         - files/ospnetwork.xml
 
     - name: Define ospnetwork libvirt network


### PR DESCRIPTION
No need to use with_fileglob without a file pattern. It does not work at present  with ansible 2.9 (probably a bug in the module).

 TASK [Copy each file over that matches the given pattern] ********************************************************************************************************************
Thursday 05 November 2020  07:49:08 +0000 (0:00:02.794)       0:00:02.818 *****